### PR TITLE
Fixed a search bug

### DIFF
--- a/templates/page/_types/contactUs.html
+++ b/templates/page/_types/contactUs.html
@@ -131,6 +131,11 @@
 
                 <hr>
                 
+                <h6>Download St. Anne App</h6>
+                The St. Anne App is available on <a href="https://itunes.apple.com/us/app/st.-anne-roman-catholic-parish/id962170758?mt=8&amp;ign-mpt=uo%3D4" target="_blank">iPhone</a>, <a href="https://play.google.com/store/apps/details?id=com.subsplash.thechurchapp.s_X3BW7W" target="_blank">Android</a>, and <a href="http://www.windowsphone.com/en-us/store/app/st-anne-roman-catholic-parish/2a195917-7357-4d24-ab52-7d511b8ae6a4" target="_blank">Windows</a>.
+                
+                <hr>
+                
                 <h6>{{ "Parish office hours"|t }}</h6>
                 {% if siteWideContent.parishOfficeHours|length %}
                   <p>

--- a/templates/page/_types/staffLanding.html
+++ b/templates/page/_types/staffLanding.html
@@ -7,6 +7,7 @@
       <div class="staff-group">
       {% for person in people %}
       
+          <a name="{{ person.slug }}"></a>
           <div class="staff-member">
             
               {% if person.profileImage is not empty %}


### PR DESCRIPTION
The search results for staff members previously returned links to pages
that didn’t exist.  In the craft admin settings, for the “people”
section I changed the “entry url format” from “clergy/{slug}” to
“about/our-leadership#{slug}”, because it appears that we have re-named
that section of our website.