### PR TITLE
Removing the item date from the display of this feed

### DIFF
--- a/templates/page/_types/ministryLanding.html
+++ b/templates/page/_types/ministryLanding.html
@@ -90,8 +90,6 @@
                   <h4 class='seth'><a href="{{ item.permalink }}" target="_blank">{{ item.title }}</a></h4>
                   <div>{{ item.summary }}</div>
                   <p class="more muted">
-                    {{ item.date|date('F d, Y') }}
-                    <span class="dot">&middot;</span>
                     <a href="{{ item.permalink }}" target='_blank'>{{ "Read More"|t }}</a>
                   </p>
                 </div>

--- a/templates/page/_types/ministryLandingWithSubnav.html
+++ b/templates/page/_types/ministryLandingWithSubnav.html
@@ -90,8 +90,6 @@
                   <h4 class='seth'><a href="{{ item.permalink }}" target="_blank">{{ item.title }}</a></h4>
                   <div>{{ item.summary }}</div>
                   <p class="more muted">
-                    {{ item.date|date('F d, Y') }}
-                    <span class="dot">&middot;</span>
                     <a href="{{ item.permalink }}" target='_blank'>{{ "Read More"|t }}</a>
                   </p>
                 </div>


### PR DESCRIPTION
The City’s pubDate is the creation date of the post instead of the
Event Date, which doesn’t make it useful for display on our website.  A
help ticket has been sent to The City to see if they will fix this. If
not, I will just use it without displaying the date here.  The event
dates will display when visitors click the Read More links.