### PR TITLE
Added another non-searchable section in Craft

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -3,7 +3,7 @@
 
 {% block content %}
   {% set query = craft.request.getParam('q') %}
-  {% set entries = craft.entries.search(query).order('score').section('and, not phoneAppPages, not featuredEvents, not search') %}
+  {% set entries = craft.entries.search(query).order('score').section('and, not pagesNoSearch, not phoneAppPages, not featuredEvents, not search') %}
    <!-- .sf-content for flex sticky footer -->
   <div class="sf-content nav-slide-element">
     <div class="page-content-container">


### PR DESCRIPTION
I wanted one with identical entry types to pages.  This can also help
keep certain redirect URLs and Phone App pages from displaying in the search page results.