### PR TITLE
Using different feeds in our website

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -121,7 +121,7 @@
 
     <div class="page-content-container">
       <div class="container news-grid">
-      <h4 class="caps-header text-center"><a href="{{ siteUrl }}connect/news-updates">{{ "Announcements"|t }}</a></h4>
+      <h4 class="caps-header text-center">{{ "Announcements"|t }}</h4>
 
       <hr class="short-divider centered">
 

--- a/templates/news/_entry.html
+++ b/templates/news/_entry.html
@@ -64,7 +64,7 @@
                   </div> <!-- .author-bio -->
                 {% endif %}
                 
-                <div style="margin:5px 0 40px"><a href="{{ siteUrl }}connect/news-updates">{{ "View more news & updates"|t }} &rsaquo;</a>
+                <div style="margin:5px 0 40px"><a href="{{ siteUrl }}news-updates">{{ "View more news & updates"|t }} &rsaquo;</a>
                 </div>
                 
                 <hr>
@@ -85,12 +85,39 @@
 
                 <h6>{{ "Subscribe"|t }}</h6>
                 <p>{{ "Get the latest news and updates from St. Anne’s in your RSS feed or email inbox"|t }}!</p>
-                {% if feeds.rssFeedUrl is not empty %}
-                  <a href="{{ feeds.rssFeedUrl.url }}" class="btn btn-light-brown-border"><i class="fa fa-rss"></i> {{"RSS Feed"|t }}</a>
+                {% if craft.locale == 'es_us' %}
+                
+                    {% if feeds.announcementsFeedUrlSpanish is not empty %}
+                    <a href="{{ feeds.announcementsFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Announcements RSS"|t }}</a><br/>
+                    {% endif %}
+                    {% if feeds.eventsFeedUrlSpanish is not empty %}
+                    <a href="{{ feeds.eventsFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Events RSS"|t }}</a><br/>
+                    {% endif %}
+                    {% if feeds.parishCalendarFeedUrlSpanish is not empty %}
+                    <a href="{{ feeds.parishCalendarFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Parish Calendar RSS"|t }}</a><br/>
+                    {% endif %}
+                    {% if feeds.podcastFeedUrlSpanish is not empty %}
+                    <a href="{{ feeds.podcastFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{ "Podcasts RSS"|t }}</a>
+                    {% endif %}
+                    
+                {% else %}
+                
+                    {% if feeds.announcementsFeedUrl is not empty %}
+                    <a href="{{ feeds.announcementsFeedUrl.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Announcements RSS"|t }}</a><br/>
+                    {% endif %}
+                    {% if feeds.eventsFeedUrl is not empty %}
+                    <a href="{{ feeds.eventsFeedUrl.url }}" class="btn btn-light-brown-border"><i class="fa fa-rss" target="_blank"></i> {{"Events RSS"|t }}</a><br/>
+                    {% endif %}
+                    {% if feeds.parishCalendarFeedUrl is not empty %}
+                    <a href="{{ feeds.parishCalendarFeedUrl.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Parish Calendar RSS"|t }}</a><br/>
+                    {% endif %}
+                    {% if feeds.podcastRss is not empty %}
+                    <a href="{{ feeds.podcastRss.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{ "Podcasts RSS"|t }}</a>
+                    {% endif %}
+                
                 {% endif %}
-                {% if feeds.podcastSubscribeEmailLink is not empty %}
-                  <a href="{{ feeds.podcastSubscribeEmailLink.url }}" class="btn btn-light-brown-border"><i class="fa fa-envelope"></i> {{ "Email Me"|t }}</a>
-                {% endif %}
+                
+                
 
               </div> <!-- .col -->
             </div> <!-- .row -->

--- a/templates/page/_types/eventsLanding.html
+++ b/templates/page/_types/eventsLanding.html
@@ -5,7 +5,30 @@
       
       {{ entry.body }}
       
-      <h3>{{ "Events"|t }}</h3>
+      <a name="eva"></a>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-5 col-md-5 col-sm-5">
+        <h3>{{ "Events"|t }}</h3>
+      </div>
+      <div class="col-lg-7 col-md-7 col-sm-7 action-links" style="text-align:right">
+        {% if craft.locale == "en_us" %}
+          {% if feeds.eventsFeedUrl is not empty %}
+            <a style="display:inline-block" href="{{ feeds.eventsFeedUrl.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Events RSS"|t }}</a>
+          {% endif %}
+        {% elseif craft.locale == "es_us" %}
+          {% if feeds.eventsFeedUrlSpanish is not empty %}
+            <a style="display:inline-block" href="{{ feeds.eventsFeedUrlSpanish.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Eventos RSS"|t }}</a>
+          {% endif %}
+        {% endif %}
+              
+        <form style="display:inline-block" action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('https://feedburner.google.com/fb/a/mailverify?uri={% if craft.locale == 'es_us' %}EventosStaAna{% else %}StAnneEvents{% endif %}', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true"> <input type="text" style="margin:0 10px 0 5px;vertical-align:middle;width:160px" name="email" placeholder="{{ "Enter your email"|t }}...." title="{{ "Enter your email address"|t }}"/><input type="hidden" value="{% if craft.locale == 'es_us' %}EventosStaAna{% else %}StAnneEvents{% endif %}" name="uri"/><input type="hidden" name="loc" value="en_US"/><button type="submit" class="btn btn-sm btn-light-blue" style="vertical-align:middle;"><i class="fa fa-check"></i> {{ "Subscribe"|t }}</button></form>
+              
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-12">
 
         <div class="featured-media-grid clearfix">
           {% set feedurl = entry.eventFeedUrl %}
@@ -55,7 +78,7 @@
           <a href="#" class="btn btn-sm btn-light-blue btn-next">October 2014 &rsaquo;</a>
         </div> #}
 
-          </div> <!-- .col -->
+          </div>
         </div> <!-- .row -->
       </div> <!-- .container -->
     </div> <!-- .page-content-container -->

--- a/templates/page/_types/mediaLanding.html
+++ b/templates/page/_types/mediaLanding.html
@@ -19,28 +19,17 @@
               <h3 class="small">{{ "Find and filter media below"|t }}</h3>
             </div>
             <div class="col-lg-7 col-md-7 col-sm-7 action-links">
-              {{ "Subscribe with"|t }}:
               {% if craft.locale == "en_us" %}
-                {% if feeds.itunesFeedUrl is not empty %}
-                <a href="{{ feeds.itunesFeedUrl.url }}"><i class="fa fa-music"></i> {{ "iTunes Podcast"|t }}</a>
-                {% endif %}
-                {% if feeds.rssFeedUrl is not empty %}
-                  <a href="{{ feeds.rssFeedUrl.url }}"><i class="fa fa-rss"></i> {{ "RSS Feed"|t }}</a>
-                {% endif %}
-                {% if feeds.podcastSubscribeEmailLink is not empty %}
-                  <a href="{{ feeds.podcastSubscribeEmailLink.url }}"><i class="fa fa-envelope"></i> {{ "Email"|t }}</a>
+                {% if feeds.podcastRss is not empty %}
+                  <a style="display:inline-block" href="{{ feeds.podcastRss.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Podcast RSS"|t }}</a>
                 {% endif %}
               {% elseif craft.locale == "es_us" %}
-                {% if feeds.itunesFeedUrlSpanish is not empty %}
-                <a href="{{ feeds.itunesFeedUrlSpanish.url }}"><i class="fa fa-music"></i> {{ "iTunes Podcast"|t }}</a>
-                {% endif %}
                 {% if feeds.podcastFeedUrlSpanish is not empty %}
-                  <a href="{{ feeds.podcastFeedUrlSpanish.url }}"><i class="fa fa-rss"></i> {{ "RSS Feed"|t }}</a>
-                {% endif %}
-                {% if feeds.podcastSubscribeEmailLinkSpanish is not empty %}
-                  <a href="{{ feeds.podcastSubscribeEmailLinkSpanish.url }}"><i class="fa fa-envelope"></i> {{ "Email"|t }}</a>
+                  <a style="display:inline-block" href="{{ feeds.podcastFeedUrlSpanish.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Audios RSS"|t }}</a>
                 {% endif %}
               {% endif %}
+              
+              <form style="display:inline-block" action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('https://feedburner.google.com/fb/a/mailverify?uri={% if craft.locale == 'es_us' %}AudiosdeParroquiaStaAna{% else %}stannecatholicpodcast{% endif %}', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true"> <input type="text" style="margin:0 10px 0 5px;vertical-align:middle;width:160px" name="email" placeholder="{{ "Enter your email"|t }}...." title="{{ "Enter your email address"|t }}"/><input type="hidden" value="{% if craft.locale == 'es_us' %}AudiosdeParroquiaStaAna{% else %}stannecatholicpodcast{% endif %}" name="uri"/><input type="hidden" name="loc" value="en_US"/><button type="submit" class="btn btn-sm btn-light-blue" style="vertical-align:middle;"><i class="fa fa-check"></i> {{ "Subscribe"|t }}</button></form>
               
             </div>
           </div>

--- a/templates/page/_types/newsUpdatesLanding.html
+++ b/templates/page/_types/newsUpdatesLanding.html
@@ -11,22 +11,7 @@
               <h3 class="small">{{ "Find and filter posts below"|t }}</h3>
             </div>
             <div class="col-lg-7 col-md-7 col-sm-7 action-links">
-              {{"Subscribe with"|t}}:
-              {% if craft.locale == "en_us" %}
-                {% if feeds.rssFeedUrl is not empty %}
-                  <a href="{{ feeds.rssFeedUrl.url }}"><i class="fa fa-rss"></i> RSS Feed</a>
-                {% endif %}
-                {% if feeds.podcastSubscribeEmailLink is not empty %}
-                  <a href="{{ feeds.podcastSubscribeEmailLink.url }}"><i class="fa fa-envelope"></i> Email</a>
-                {% endif %}
-              {% elseif craft.locale == "es_us" %}
-                {% if feeds.rssFeedUrlSpanish is not empty %}
-                  <a href="{{ feeds.rssFeedUrlSpanish.url }}"><i class="fa fa-rss"></i> {{ "RSS Feed"|t }}</a>
-                {% endif %}
-                {% if feeds.podcastSubscribeEmailLinkSpanish is not empty %}
-                  <a href="{{ feeds.podcastSubscribeEmailLinkSpanish.url }}"><i class="fa fa-envelope"></i> {{ "Email"|t }}</a>
-                {% endif %}
-              {% endif %}
+             
             </div>
           </div>
         </div>

--- a/templates/partials/filters/_news-updates-filters.twig
+++ b/templates/partials/filters/_news-updates-filters.twig
@@ -36,7 +36,7 @@
     </select>
   </label>
   <label class="select" data-action='bymonth'>
-  {% set lastPost = craft.entries.section('newsUpdates').postDate('<=' ~ (now.date)).order('postDate DESC').first() %}
+  {% set lastPost = craft.entries.section('newsUpdates').postDate('<=' ~ (now.date)).order('postDate ASC').first() %}
   {% if lastPost|length %}
   {% set lastYear = lastPost.postDate|date('Y') %}
     <select name="" id="">


### PR DESCRIPTION
News & Updates was getting difficult to maintain, because we don’t have
enough people willing to write news articles.  I’ve replaced it with
Announcements, for now, but I don’t want to disable all the previous
News items.  I removed the News Landing page from the main menu and
made a version of it in a different area that doesn’t show up in
searches on the website.