### PR TITLE
Added the ability to put events from The City above the content

### DIFF
--- a/templates/page/_types/ministryLanding.html
+++ b/templates/page/_types/ministryLanding.html
@@ -107,6 +107,11 @@
         
         {% endif %}  
     {% endif %}
+    
+    {% if entry.bodyBelowEvents is not empty %}
+        <br/><br/>
+        {{ entry.bodyBelowEvents }}
+    {% endif %}
         
         	
       </div> <!-- .container -->


### PR DESCRIPTION
This helps for ministry pages with large amounts of content, such as
our Pro-Life page.  People don’t have to scroll so far to see upcoming
events and activities.