### PR TITLE
Added header for the feed we pull in from The City

### DIFF
--- a/templates/page/_types/ministryLanding.html
+++ b/templates/page/_types/ministryLanding.html
@@ -70,17 +70,21 @@
         {{ entry.body }}
         
     {% if entry.cityGroupId is not empty %}
-        {% if entry.title != "Funerals" %}
-          {% set citygroupid = entry.cityGroupId|raw %}
-          {% set feedurl = "http://stanneaz.onthecity.org/plaza?group_id=#{citygroupid}&format=rss" %}
-          {% set limit = 6 %}
-          {% set cache = "P0M" %}
-          {% set items = craft.feeds.getFeedItems(feedurl, limit, 0, cache) %}
+        {% set citygroupid = entry.cityGroupId|raw %}
+        {% set feedurl = "http://stanneaz.onthecity.org/plaza?group_id=#{citygroupid}&format=rss" %}
+        {% set limit = 6 %}
+        {% set cache = "P0M" %}
+        {% set items = craft.feeds.getFeedItems(feedurl, limit, 0, cache) %}
+        
+        {% if entry.ministryFeedHeader is not empty %}
+            {% set ministryRssHeader = entry.ministryFeedHeader|raw %}
+        {% else %}
+            {% set ministryRssHeader = "Activities, Events, News, and Information"|t %}
+        {% endif %}
 
-          {% if items|length %}
-          
-           
-        <h3>{{ "Activities, Events, News, and Information"|t }}</h3>
+        {% if items|length %}
+            
+        <h3>{{ ministryRssHeader }}</h3>
         <div class="featured-media-grid clearfix">
           {% for item in items %}
             <div class="featured-media-box short">
@@ -98,12 +102,7 @@
             {% endfor %}
         </div> <!-- .row -->
 
-        <strong><a href="http://stanneaz.onthecity.org/plaza?group_id={{ citygroupid }}" target="_blank">{{ "View More"|t }}</a>
-        
-        {% endif %}
-        
-       
-        </strong>
+        <strong><a href="http://stanneaz.onthecity.org/plaza?group_id={{ citygroupid }}" target="_blank">{{ "View More"|t }}</a></strong>
         
         {% endif %}  
     {% endif %}

--- a/templates/page/_types/ministryLandingWithSubnav.html
+++ b/templates/page/_types/ministryLandingWithSubnav.html
@@ -72,13 +72,19 @@
         {% if entry.cityGroupId is not empty %}
           {% set citygroupid = entry.cityGroupId|raw %}
           {% set feedurl = "http://stanneaz.onthecity.org/plaza?group_id=#{citygroupid}&format=rss" %}
-          {% set limit = 3 %}
+          {% set limit = 6 %}
           {% set cache = "P0M" %}
           {% set items = craft.feeds.getFeedItems(feedurl, limit, 0, cache) %}
+          
+          {% if entry.ministryFeedHeader is not empty %}
+              {% set ministryRssHeader = entry.ministryFeedHeader|raw %}
+          {% else %}
+              {% set ministryRssHeader = "Activities, Events, News, and Information"|t %}
+          {% endif %}
 
           {% if items|length %}
           
-            <h3>{{ "Latest posts for this group on The City Plaza"|t }}</h3>
+            <h3>{{ ministryRssHeader }}</h3>
           
         <div class="featured-media-grid clearfix">
           {% for item in items %}


### PR DESCRIPTION
Some ministries and groups may not wish to display the words,
“Activities, Events, News, and Information” over their feed.  For
instance, it doesn’t really look good to display that on the Funeral
Announcements page.