### PR TITLE
Fixed feed URL for Ministry Landing pages

### DIFF
--- a/templates/page/_types/ministryLanding.html
+++ b/templates/page/_types/ministryLanding.html
@@ -71,7 +71,7 @@
         
     {% if entry.cityGroupId is not empty %}
         {% set citygroupid = entry.cityGroupId|raw %}
-        {% set feedurl = "http://stanneaz.onthecity.org/plaza?group_id=#{citygroupid}&format=rss" %}
+        {% set feedurl = "http://stanneaz.onthecity.org/plaza?group_id={citygroupid}&format=rss" %}
         {% set limit = 6 %}
         {% set cache = "P0M" %}
         {% set items = craft.feeds.getFeedItems(feedurl, limit, 0, cache) %}


### PR DESCRIPTION
The funerals page wasn’t displaying the latest events until this change
was made.  I tested the feed URL from The City, and found it didn’t
display correctly with the # anymore.